### PR TITLE
Fixed #17

### DIFF
--- a/android/src/main/java/com/reactlibrary/UniconsPackage.java
+++ b/android/src/main/java/com/reactlibrary/UniconsPackage.java
@@ -16,6 +16,10 @@ public class UniconsPackage implements ReactPackage {
         return Arrays.<NativeModule>asList(new UniconsModule(reactContext));
     }
 
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+      return Collections.emptyList();
+    }
+
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();


### PR DESCRIPTION
Takes care of `Task :iconscout_react-native-unicons:compileDebugJavaWithJavac FAILED` during build on react-native ^0.63.4 from #17 